### PR TITLE
Run as non-root user:group (53000:53000)

### DIFF
--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -5,6 +5,9 @@ COPY nats-streaming-server /nats-streaming-server
 # Expose client and management ports
 EXPOSE 4222 8222
 
+# Run as a numbered non-root user for secure environments
+USER 53000:53000
+
 # Run with default memory based store 
 ENTRYPOINT ["/nats-streaming-server"]
 CMD ["-m", "8222"]


### PR DESCRIPTION
For security-strict environments (such as a kubernetes cluster with a `PodSecurityPolicy` of `RunAsNonRoot`), the best practice is for images to not be running as the default root user.

This PR aims to allow for this use case by default in the image with a randomly chosen uncommon user id and a matching group id.

Note: `nobody` would also not work in the use case mentioned above as it needs to be a numbered user in those cases to avoid the theoretical risk of linking the nobody user to the `root` user/group.

I realize that one could set the `securityContext` of a pod but we have a use case where we may have another container inside the pod that needs to run with a _different_ userid, so setting the securityContext in that case also doesn't work. I would personally prefer if the images we bring in themselves set users that aren't root/nobody.