### PR TITLE
Update CA certificates

### DIFF
--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -1,5 +1,10 @@
+FROM alpine:3.11 as alpine
+
+RUN apk add -U --no-cache ca-certificates
+
 FROM scratch
 
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY nats-streaming-server /nats-streaming-server
 
 # Expose client and management ports

--- a/arm32v6/Dockerfile
+++ b/arm32v6/Dockerfile
@@ -1,5 +1,10 @@
+FROM alpine:3.11 as alpine
+
+RUN apk add -U --no-cache ca-certificates
+
 FROM scratch
 
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY nats-streaming-server /nats-streaming-server
 
 # Expose client and management ports

--- a/arm32v7/Dockerfile
+++ b/arm32v7/Dockerfile
@@ -1,10 +1,15 @@
+FROM alpine:3.11 as alpine
+
+RUN apk add -U --no-cache ca-certificates
+
 FROM scratch
 
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY nats-streaming-server /nats-streaming-server
 
 # Expose client and management ports
 EXPOSE 4222 8222
 
-# Run with default memory based store 
+# Run with default memory based store
 ENTRYPOINT ["/nats-streaming-server"]
 CMD ["-m", "8222"]

--- a/arm64v8/Dockerfile
+++ b/arm64v8/Dockerfile
@@ -1,10 +1,15 @@
+FROM alpine:3.11 as alpine
+
+RUN apk add -U --no-cache ca-certificates
+
 FROM scratch
 
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY nats-streaming-server /nats-streaming-server
 
 # Expose client and management ports
 EXPOSE 4222 8222
 
-# Run with default memory based store 
+# Run with default memory based store
 ENTRYPOINT ["/nats-streaming-server"]
 CMD ["-m", "8222"]


### PR DESCRIPTION
Containers created with the existing `nats-streaming` image do not contain (updated) CA certificates:

```
$ docker run -it nats-streaming:latest -DV -ns nats://<server>:<port>
[1] 2020/01/11 12:28:03.777436 [INF] STREAM: Starting nats-streaming-server[test-cluster] version 0.16.2
[1] 2020/01/11 12:28:03.777482 [INF] STREAM: ServerID: TOSU3vQTOQ2lZrak8oekYn
[1] 2020/01/11 12:28:03.777504 [INF] STREAM: Go version: go1.11.13
[1] 2020/01/11 12:28:03.777508 [INF] STREAM: Git commit: [910d6e1]
[1] 2020/01/11 12:28:03.789907 [INF] STREAM: Shutting down.
[1] 2020/01/11 12:28:03.789945 [FTL] STREAM: Failed to start: x509: certificate signed by unknown authority
```

This PR copies the CA certificates from `alpine` and resolves this issue.