### PR TITLE
Use proper arch name on Alpine for arm64 architecture

### DIFF
--- a/0.18.0/alpine3.12/Dockerfile
+++ b/0.18.0/alpine3.12/Dockerfile
@@ -5,7 +5,7 @@ ENV NATS_STREAMING_SERVER 0.18.0
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		aarch64|arm64) natsArch='arm64'; sha256='ff2a51618b79685264f980fe868f1c7af583c419b6406cc63d4811f3c98ca8fe' ;; \
+		aarch64) natsArch='arm64'; sha256='ff2a51618b79685264f980fe868f1c7af583c419b6406cc63d4811f3c98ca8fe' ;; \
 		armhf) natsArch='arm6'; sha256='629e17255f12fd80e051772a6dd18a7f65e692b4abef0786b421eb8b6ab85db4' ;; \
 		armv7) natsArch='arm7'; sha256='94e499af6a6391519315e8bcd5127c43c1d1a442ef945956286e77b4366c92c9' ;; \
 		x86_64) natsArch='amd64'; sha256='6252e9262efc81a41ade3f43b68e014d1e635d3e3bf9cbcd2b09c3a030a0d5e6' ;; \


### PR DESCRIPTION
Explanation is here:
https://github.com/docker-library/official-images/pull/8010#issuecomment-665852100
https://github.com/docker-library/official-images/pull/8010#issuecomment-665854650

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>