### PR TITLE
Fix the Dockerfile's "FROM alpine:3.15" to "FROM alpine:3.16"

### DIFF
--- a/0.25.2/alpine3.16/Dockerfile
+++ b/0.25.2/alpine3.16/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV NATS_STREAMING_SERVER 0.25.2
 


### PR DESCRIPTION
Signed-off-by: Ivan Kozlovic <ivan@synadia.com>